### PR TITLE
add process exit

### DIFF
--- a/lib/helpers/optimizer-command.js
+++ b/lib/helpers/optimizer-command.js
@@ -38,5 +38,6 @@ optimizer.optimizePage(
         var files = optimizedPage.getJavaScriptFiles();
         files.push(initFile);
         fs.outputJsonSync(process.argv[4], files);
+        process.exit(0);
     }
 );


### PR DESCRIPTION
I am having issue with optimizer-command.js. It is always running, I checked karma-lasso, found they have process.exit(0), maybe it's way to fix it?
